### PR TITLE
Update BASEDIR

### DIFF
--- a/theory.sh
+++ b/theory.sh
@@ -11,7 +11,7 @@
 
 DATE=$(date +"%Y-%m-%d %H:%M:%S")
 HOST=$(hostname)
-BASEDIR=/var/lib/boinc-client
+BASEDIR=/var/lib/boinc
 ERRLOG=stderr.txt # not used yet in this script, this file is in $BASEDIR/slots/$SLOT/stderr.txt for each job - check if you have problems
 RUNRIVET=cernvm/shared/runRivet.log
 TMPRUNRIVET=/tmp/runRivet.log


### PR DESCRIPTION
BOINC's default working directory on Linux has been modified to `/var/lib/boinc` in 2018.
See:
https://github.com/BOINC/boinc/commit/344ddabeb4e0b453ab7c3be8d5d1d5e478de2561

The script should use that `BASEDIR` to avoid failures on many recent installations.
On systems still using `/var/lib/boinc-client` the directory name should be renamed and the BOINC service file should be updated accordingly.